### PR TITLE
Vitiligo Level Bugfix

### DIFF
--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -21,7 +21,7 @@ BONUS
 	resistance = -1
 	stage_speed = -1
 	transmittable = -2
-	level = 4
+	level = 5
 	severity = 1
 
 /datum/symptom/vitiligo/Activate(datum/disease/advance/A)
@@ -65,7 +65,7 @@ BONUS
 	resistance = -1
 	stage_speed = -1
 	transmittable = -2
-	level = 4
+	level = 5
 	severity = 1
 
 /datum/symptom/revitiligo/Activate(datum/disease/advance/A)


### PR DESCRIPTION
:cl: Baby's first PR
fix: Vitiligo and Revitiligo were listed as level 5, but had level 4.
/:cl:

[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)
[]: # (See here for how to easily make a changelog: https://github.com/tgstation/tgstation/wiki/Changelogs. An example changelog has been provided below. Please edit or remove)


:cl: optional name here
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
fix: fixed a few things
wip: added a few works in progress
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
experiment: added an experimental thingy
/:cl:

[]: # (Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:)
